### PR TITLE
docker group: add list, otherwise current user

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ All variables are set within `default/main.yml`.
 | `docker_apt_repo_key_fingerprint` | Packaging signing key fingerprint. Used to fetch GPG package signing key from key server. |
 | `key_server`                      | GPG public key server which can be used to retrieve the key used to sign Docker packages  |
 | `docker_apt_repo`                 | APT `sources.list.d` template used to allow package installation from upstream repo       |
+| `docker_users`                    | List of users that should be added to the `docker` user group                             |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,4 +29,7 @@ docker_apt_repo: >
   deb https://download.docker.com/linux/ubuntu
   {{ ansible_distribution_release }} stable
 
+# Defaults to the user running the playbook if not set
+docker_users: []
+
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,4 +51,12 @@
   pip:
     name: "{{ docker_related_python_modules }}"
 
+# Fallback to current user if not set elsewhere
+- name: Add docker users to the docker group.
+  user:
+    name: "{{ item }}"
+    groups: docker
+    append: true
+  with_items: "{{ docker_users | default(lookup('env','USER')) }}"
+
 ...


### PR DESCRIPTION
Attempt to reference list of users, otherwise fall back to current user logged in.

fixes #5