### PR TITLE
Suggest localhost as playbook target

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ None
           name: atc0005.docker-host
 ```
 
+Change `docker-hosts` to `localhost` if you wish to use this playbook directly
+on the system where the playbook is running (e.g., one-off testing).
+
 ## Installing the role
 
 ### Create `requirements.yml` file


### PR DESCRIPTION
Just in case the user wishes to quickly setup a throwaway test host for one-off testing.